### PR TITLE
Explicit fast forward only fetchs

### DIFF
--- a/src/bump-version.js
+++ b/src/bump-version.js
@@ -106,7 +106,7 @@ const main = async config => {
     const branch = autoBumpConfig['sync-branch'];
     await executeScript([
       `git config remote.gh.url >/dev/null || git remote add gh https://${config.token}@github.com/${config.repoSlug}.git`,
-      `git pull gh ${branch} && git checkout ${branch} && git reset --hard master`,
+      `git pull --ff-only gh ${branch} && git checkout ${branch} && git reset --hard master`,
       `git push gh ${branch}:refs/heads/${branch} --force || (git remote remove gh && exit 12)`,
       'git remote remove gh'
     ]);
@@ -116,7 +116,7 @@ const main = async config => {
     const branch = autoBumpConfig['merge-branch'];
     await executeScript([
       `git config remote.gh.url >/dev/null || git remote add gh https://${config.token}@github.com/${config.repoSlug}.git`,
-      `git pull gh ${branch} && git checkout ${branch} && git merge master`,
+      `git pull --ff-only gh ${branch} && git checkout ${branch} && git merge master`,
       `git push gh ${branch}:refs/heads/${branch} || (git remote remove gh && exit 12)`,
       'git remote remove gh'
     ]);


### PR DESCRIPTION
In order to avoid the warning or error by specifying the desired behavior, Fast forward only fetchs.

```
 warning: Pulling without specifying how to reconcile divergent branches is
   discouraged. You can squelch this message by running one of the following
   commands sometime before your next pull:
   
     git config pull.rebase false  # merge (the default strategy)
     git config pull.rebase true   # rebase
     git config pull.ff only       # fast-forward only
   
   You can replace "git config" with "git config --global" to set a default
   preference for all repositories. You can also pass --rebase, --no-rebase,
   or --ff-only on the command line to override the configured default per
   invocation.
```
