### PR TITLE
Refreshed and improved, glitchless edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Options:
   -d, --default-config, --default      Override update-node configuration
                                        default path                    [boolean]
   -c, --clean                          Run on a clean state            [boolean]
+  -i, --run-npm-install                Run npm install after patching
+                                       package.json (default, disable with
+                                       --no-run-npm-install)
+                                                       [boolean] [default: true]
+  -b, --pre-commit-bump-command        Command to run before to commit (changes
+                                       will be commited)                 [array]
   -p, --pre-clean-command              Run before to clean state         [array]
   -P, --post-clean-command             Run on a clean state              [array]
   -f, --force                          Git Push with force changes

--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ Options:
   -d, --default-config, --default      Override update-node configuration
                                        default path                    [boolean]
   -c, --clean                          Run on a clean state            [boolean]
-  -i, --run-npm-install                Run npm install after patching
+      --sync-lock                      Run npm install or yarn after patching
                                        package.json (default, disable with
-                                       --no-run-npm-install)
-                                                       [boolean] [default: true]
+                                       --no-sync-lock) [boolean] [default: true]
   -b, --pre-commit-bump-command        Command to run before to commit (changes
                                        will be commited)                 [array]
   -p, --pre-clean-command              Run before to clean state         [array]

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "semver": "^7.6.3",
         "split2": "^3.2.2",
         "through2": "^4.0.2",
-        "yaml": "^2.5.1",
+        "yaml": "^2.6.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -34,7 +34,7 @@
       "devDependencies": {
         "@coorpacademy/eslint-plugin-coorpacademy": "14.0.0",
         "ava": "^5.3.1",
-        "eslint": "^8.57.0",
+        "eslint": "^8.57.1",
         "nyc": "^17.1.0"
       },
       "engines": {
@@ -561,9 +561,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -585,14 +585,14 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
+        "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -2545,17 +2545,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -7998,9 +7999,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
+      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -8426,9 +8427,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true
     },
     "@hapi/hoek": {
@@ -8445,12 +8446,12 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "dev": true,
       "requires": {
-        "@humanwhocodes/object-schema": "^2.0.2",
+        "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -9832,16 +9833,16 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -13651,9 +13652,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
+      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ=="
     },
     "yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
     "semver": "^7.6.3",
     "split2": "^3.2.2",
     "through2": "^4.0.2",
-    "yaml": "^2.5.1",
+    "yaml": "^2.6.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@coorpacademy/eslint-plugin-coorpacademy": "14.0.0",
     "ava": "^5.3.1",
-    "eslint": "^8.57.0",
+    "eslint": "^8.57.1",
     "nyc": "^17.1.0"
   }
 }

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -4,6 +4,7 @@ set -e
 echo "> Linking update-node"
 npm link
 echo
+export NVM_DIR="$(realpath "$(dirname "$0")/../test/integration")"
 
 cd test/integration
 if [ -d .git ]; then

--- a/src/bump-dependencies.js
+++ b/src/bump-dependencies.js
@@ -20,6 +20,8 @@ const {syncGithub} = require('./core/github');
 const {findLatest} = require('./core/node');
 const {makeError, formatEventualSuffix} = require('./core/utils');
 
+const LOAD_NVM = '. ${NVM_DIR:-$HOME/.nvm}/nvm.sh && nvm use'; // eslint-disable-line no-template-curly-in-string
+
 const bumpNodeVersion = async (latestNode, config) => {
   process.stdout.write(c.bold.blue(`\n\n⬆️  About to bump node version:\n`));
   const {exact, loose} = config.node;
@@ -34,9 +36,8 @@ const bumpNodeVersion = async (latestNode, config) => {
     config.lernaMonorepo && updateLearnaPackageEngines(nodeVersion, latestNode.npm, {exact, loose})
   ]);
   // Post commands to synchronise the package-lock.json
-  // eslint-disable-next-line no-template-curly-in-string
-  if (runNpmInstall) await executeScript(['. ${NVM_DIR:-$HOME/.nvm}/nvm.sh && nvm use', 'npm i']);
-  if (!_.isEmpty(preCommitBumpCommand)) await executeScript(preCommitBumpCommand);
+  if (runNpmInstall) await executeScript([LOAD_NVM, 'npm i']);
+  if (!_.isEmpty(preCommitBumpCommand)) await executeScript([LOAD_NVM, ...preCommitBumpCommand]);
 
   const messageSuffix = formatEventualSuffix(config.argv.message);
 

--- a/src/bump-dependencies.js
+++ b/src/bump-dependencies.js
@@ -15,6 +15,7 @@ const {
 } = require('./updatees/package');
 const updateDockerfile = require('./updatees/dockerfile');
 const {commitFiles, currentUser} = require('./core/git');
+const {executeScript} = require('./core/script');
 const {syncGithub} = require('./core/github');
 const {findLatest} = require('./core/node');
 const {makeError, formatEventualSuffix} = require('./core/utils');
@@ -22,7 +23,7 @@ const {makeError, formatEventualSuffix} = require('./core/utils');
 const bumpNodeVersion = async (latestNode, config) => {
   process.stdout.write(c.bold.blue(`\n\n⬆️  About to bump node version:\n`));
   const {exact, loose} = config.node;
-  const {scope} = config.argv;
+  const {scope, preCommitBumpCommand, runNpmInstall} = config.argv;
   const nodeVersion = _.trimCharsStart('v', latestNode.version);
   await Promise.all([
     updateServerless(nodeVersion, config.node.serverless),
@@ -32,6 +33,10 @@ const bumpNodeVersion = async (latestNode, config) => {
     updateDockerfile(nodeVersion, config.node.dockerfile),
     config.lernaMonorepo && updateLearnaPackageEngines(nodeVersion, latestNode.npm, {exact, loose})
   ]);
+  // Post commands to synchronise the package-lock.json
+  // eslint-disable-next-line no-template-curly-in-string
+  if (runNpmInstall) await executeScript(['. ${NVM_DIR:-$HOME/.nvm}/nvm.sh && nvm use', 'npm i']);
+  if (!_.isEmpty(preCommitBumpCommand)) await executeScript(preCommitBumpCommand);
 
   const messageSuffix = formatEventualSuffix(config.argv.message);
 

--- a/src/bump-dependencies.js
+++ b/src/bump-dependencies.js
@@ -25,7 +25,7 @@ const LOAD_NVM = '. ${NVM_DIR:-$HOME/.nvm}/nvm.sh && nvm use'; // eslint-disable
 const bumpNodeVersion = async (latestNode, config) => {
   process.stdout.write(c.bold.blue(`\n\n⬆️  About to bump node version:\n`));
   const {exact, loose} = config.node;
-  const {scope, preCommitBumpCommand, runNpmInstall} = config.argv;
+  const {scope, preCommitBumpCommand, syncLock} = config.argv;
   const nodeVersion = _.trimCharsStart('v', latestNode.version);
   await Promise.all([
     updateServerless(nodeVersion, config.node.serverless),
@@ -36,7 +36,11 @@ const bumpNodeVersion = async (latestNode, config) => {
     config.lernaMonorepo && updateLearnaPackageEngines(nodeVersion, latestNode.npm, {exact, loose})
   ]);
   // Post commands to synchronise the package-lock.json
-  if (runNpmInstall) await executeScript([LOAD_NVM, 'npm i']);
+  if (syncLock)
+    await executeScript([
+      LOAD_NVM,
+      config.packageManager === 'npm' ? 'npm install' : 'yarn --ignore-engines --ignore-scripts'
+    ]);
   if (!_.isEmpty(preCommitBumpCommand)) await executeScript([LOAD_NVM, ...preCommitBumpCommand]);
 
   const messageSuffix = formatEventualSuffix(config.argv.message);

--- a/src/bump-version.js
+++ b/src/bump-version.js
@@ -119,15 +119,12 @@ const main = async config => {
   if (autoBumpConfig['merge-branch']) {
     const branch = autoBumpConfig['merge-branch'];
     await executeScript([
-      `git config remote.gh.url >/dev/null || git remote add gh https://${config.token}@github.com/${config.repoSlug}.git`
+      `git config remote.gh.url >/dev/null || git remote add gh https://${config.token}@github.com/${config.repoSlug}.git`,
+      `git fetch gh && git checkout -B ${branch} gh/${branch} && git merge master`,
+      `git push gh ${branch}:refs/heads/${branch} || (git remote remove gh && exit 12)`,
+      'git remote remove gh'
     ]);
-    await executeScript([
-      `git fetch gh && git checkout -B ${branch} gh/${branch} && git merge master`
-    ]);
-    await executeScript([
-      `git push gh ${branch}:refs/heads/${branch} || (git remote remove gh && exit 12)`
-    ]);
-    await executeScript(['git remote remove gh']);
+
     process.stdout.write(c.bold.green(`Successfully merged branch ${branch}\n`));
   }
 };

--- a/src/bump-version.js
+++ b/src/bump-version.js
@@ -98,7 +98,7 @@ const main = async config => {
   if (!config.local)
     await pushFiles('master', config.token, config.repoSlug, {
       tags: true,
-      forceFlag: config.forceFlag
+      forceFlag: '--force'
     });
   process.stdout.write(c.bold.green(`Successfully made a ${releaseType} release\n`));
   if (autoBumpConfig.publish || autoBumpConfig['publish-command']) {

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,8 @@ const yargs = require('yargs')
     alias: 'c'
   })
   .option('run-npm-install', {
-    describe: 'Command to run before to commit (disable with --no-run-npm-install)',
+    describe:
+      'Run npm install after patching package.json (default, disable with --no-run-npm-install)',
     boolean: true,
     alias: 'i',
     default: true

--- a/src/index.js
+++ b/src/index.js
@@ -129,11 +129,10 @@ const yargs = require('yargs')
     boolean: true,
     alias: 'c'
   })
-  .option('run-npm-install', {
+  .option('sync-lock', {
     describe:
-      'Run npm install after patching package.json (default, disable with --no-run-npm-install)',
+      'Run npm install or yarn after patching package.json (default, disable with --no-sync-lock)',
     boolean: true,
-    alias: 'i',
     default: true
   })
   .option('pre-commit-bump-command', {

--- a/src/index.js
+++ b/src/index.js
@@ -129,6 +129,18 @@ const yargs = require('yargs')
     boolean: true,
     alias: 'c'
   })
+  .option('run-npm-install', {
+    describe: 'Command to run before to commit (disable with --no-run-npm-install)',
+    boolean: true,
+    alias: 'i',
+    default: true
+  })
+  .option('pre-commit-bump-command', {
+    describe: 'Command to run before to commit (changes will be commited)',
+    string: true,
+    alias: 'b',
+    array: true
+  })
   .option('pre-clean-command', {
     describe: 'Run before to clean state',
     string: true,

--- a/src/updatees/package.js
+++ b/src/updatees/package.js
@@ -93,7 +93,7 @@ const updateLock = async (packageManager = 'npm') => {
   process.stdout.write(`+ Updating dependencies lock with ${c.bold.yellow(packageManager)} 🔐 :\n`);
 
   await executeScript([
-    packageManager === 'npm' ? 'npm install' : 'yarn --ignore-engines --ignore-scripts ',
+    packageManager === 'npm' ? 'npm install' : 'yarn --ignore-engines --ignore-scripts',
     'echo "Updated Locks"'
   ]);
 };

--- a/test/integration/nvm.sh
+++ b/test/integration/nvm.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+nvm () {
+    echo nope nope
+}


### PR DESCRIPTION
#143 and #147 follow up, with few enhancement and glitch fixes

- Sync the package-lock (by default, and with node nvm version loaded) 🔄 
- Add hook `-b`/`--pre-commit-bump-command` to inject commands (like updating a specific package with `ncu`) 🪝 
- Restore force push for the autobump ⛑️ 