### PR TITLE
Fix typo in the clean git command :space_invader:

### DIFF
--- a/src/core/git.js
+++ b/src/core/git.js
@@ -33,7 +33,7 @@ const cleanAndSyncRepo = ({branch = 'master', preCleanCommand = [], postCleanCom
     ...preCleanCommand,
     'git stash',
     `git checkout ${branch}`,
-    `if git rev-parse --abbrev-ref @--symbolic-full-name ${branch} ; then git pull; fi`, // pull only if upstream
+    `if git rev-parse --abbrev-ref --symbolic-full-name ${branch} ; then git pull; fi`, // pull only if upstream
     ...postCleanCommand
   ]);
 

--- a/src/core/git.js
+++ b/src/core/git.js
@@ -33,7 +33,7 @@ const cleanAndSyncRepo = ({branch = 'master', preCleanCommand = [], postCleanCom
     ...preCleanCommand,
     'git stash',
     `git checkout ${branch}`,
-    `if git rev-parse --abbrev-ref --symbolic-full-name ${branch} ; then git pull; fi`, // pull only if upstream
+    `if git rev-parse --abbrev-ref --symbolic-full-name @{u} ; then git pull; fi`, // pull only if upstream
     ...postCleanCommand
   ]);
 


### PR DESCRIPTION
the @ was concatenated to the option. 
Glitch introduced by https://github.com/CoorpAcademy/update-node/pull/147

![Capture d’écran 2025-04-01 à 14 15 35](https://github.com/user-attachments/assets/ae602a9d-89e7-4602-992a-a57cca04bb93)
