### PR TITLE
Do not introduce a npm engine when non existing :no_entry:

### DIFF
--- a/src/updatees/package.js
+++ b/src/updatees/package.js
@@ -37,7 +37,9 @@ const updatePackageEngines = async (node, npm, pkg, {exact = false, loose = true
       node ? `${prefix ? prefix : getSemverPrefix(existingVersion)}${node}` : existingVersion
     ),
     _.update('engines.npm', existingVersion =>
-      npm ? `${prefix ? prefix : getSemverPrefix(existingVersion)}${npm}` : existingVersion
+      existingVersion && npm
+        ? `${prefix ? prefix : getSemverPrefix(existingVersion)}${npm}`
+        : existingVersion
     )
   )(await readPackage(pkg));
 


### PR DESCRIPTION
Currently, running a bump node to a yarn package cause the introduction of a npm entry.


This is not intended and notably breaks heroku deployments.

This was locally tested, running a bump on a project using yarn.
This should be released as a patch